### PR TITLE
implement shell filter

### DIFF
--- a/src/PikaObj.c
+++ b/src/PikaObj.c
@@ -1091,15 +1091,15 @@ static FilterReturn _do_message_filter( PikaObj* self,
             if (0 == message_size) {
                 /* message match */
                 if (NULL != msg->handler) {
-                    if (msg->handler(msg, self, shell)) {
-                        /* message is handled */
-                        if (msg->is_visible) {
-                            return __FILTER_SUCCESS_GET_ALL_PEEKED;
-                        } 
-
-                        return __FILTER_SUCCESS_DROP_ALL_PEEKED;
+                    if (!msg->handler(msg, self, shell)) {
+                        break;
                     }
                 }
+                /* message is handled */
+                if (msg->is_visible) {
+                    return __FILTER_SUCCESS_GET_ALL_PEEKED;
+                }
+                return __FILTER_SUCCESS_DROP_ALL_PEEKED;
             }
         } while(0);
         

--- a/src/__default_filter_msg_def.h
+++ b/src/__default_filter_msg_def.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the PikaScript project.
+ * http://github.com/pikastech/pikascript
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 GorgonMeducer ?? embedded_zhuoran@hotmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#undef add_filter_msg
+#undef add_filter_item
+#undef __add_filter_msg
+#undef __add_filter_item
+#undef __NO_FILTER_HANLDER__
+
+
+#if defined(__MSG_TABLE)
+    #define __add_filter_msg(__name, __msg, ...)                                \
+        {                                                                       \
+            .message = (const uint8_t []){__msg},                               \
+            .size = sizeof((const uint8_t []){__msg}) - 1,                      \
+            .handler = _filter_msg_##__name##_handler,                          \
+            __VA_ARGS__                                                         \
+        },
+    #define __add_filter_item(__name, ...)                                      \
+        {                                                                       \
+            .handler = _filter_msg_##__name##_handler,                          \
+            __VA_ARGS__                                                         \
+        },
+#endif
+
+#if defined(__MSG_DECLARE)
+    #define __add_filter_msg(__name, __msg, ...)                                \
+            PIKA_BOOL _filter_msg_##__name##_handler(   FilterItem *msg,        \
+                                                        PikaObj* self,          \
+                                                        ShellConfig* shell);
+    #define __add_filter_item(__name, ...)                                      \
+            PIKA_BOOL _filter_msg_##__name##_handler(   FilterItem *msg,        \
+                                                        PikaObj* self,          \
+                                                        ShellConfig* shell);
+#endif
+
+#undef __MSG_TABLE
+#undef __MSG_DECLARE
+
+
+#define add_filter_msg(__name, __msg, ...)                                      \
+            __add_filter_msg(__name, __msg, ##__VA_ARGS__)
+#define add_filter_item(__name, ...)                                            \
+            __add_filter_item(__name, ##__VA_ARGS__)
+#define __NO_FILTER_HANLDER__   .handler = NULL

--- a/src/__default_filter_msg_table.cfg
+++ b/src/__default_filter_msg_table.cfg
@@ -68,14 +68,6 @@ add_filter_msg(bye_pika,    "bye pika", .is_case_insensitive = PIKA_TRUE)
  *              __NO_FILTER_HANLDER__,
  *          )
  */
- 
-       add_filter_item(
-               example_array,
-               .message = (const uint8_t []){'a','b','c'},
-               .size = 3,
-               __NO_FILTER_HANLDER__,
-           )
-
 
 #if defined(__clang__)
 #   pragma clang diagnostic pop

--- a/src/__default_filter_msg_table.cfg
+++ b/src/__default_filter_msg_table.cfg
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the PikaScript project.
+ * http://github.com/pikastech/pikascript
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 GorgonMeducer ?? embedded_zhuoran@hotmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "__default_filter_msg_def.h"
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wunknown-warning-option"
+#   pragma clang diagnostic ignored "-Winitializer-overrides"
+#endif
+
+/* add your own message filter here with syntax:
+ *
+ *      add_filter_msg(
+ *          <name>,
+ *          <string>,
+ *          [.is_visible = PIKA_TRUE,]
+ *          [.is_case_insensitive = PIKA_TRUE,] 
+ *          [.ignore_mask = mask value,]
+ *          [.target = your own object address/value,]
+ *      )
+ */
+
+add_filter_msg(hi_pika,     "Hi Pika")
+add_filter_msg(bye_pika,    "bye pika", .is_case_insensitive = PIKA_TRUE)
+
+/* add your own message item here with syntax:
+ *
+ *      add_filter_item(
+ *          <name>,
+ *          .message = (const uint8_t []){< num0, num1, ... >},
+ *          .size = <array size>,
+ *          [.is_visible = PIKA_TRUE,]
+ *          [.is_case_insensitive = PIKA_TRUE,] 
+ *          [.ignore_mask = mask value,]
+ *          [.target = your own object address/value,]
+ *      )
+ * 
+ * for example:
+ * 
+ *      add_filter_item(
+ *              example_array,
+ *              .message = (const uint8_t []){'a','b','c'},
+ *              .size = 3,
+ *              __NO_FILTER_HANLDER__,
+ *          )
+ */
+ 
+       add_filter_item(
+               example_array,
+               .message = (const uint8_t []){'a','b','c'},
+               .size = 3,
+               __NO_FILTER_HANLDER__,
+           )
+
+
+#if defined(__clang__)
+#   pragma clang diagnostic pop
+#endif

--- a/src/__pika_ooc.h
+++ b/src/__pika_ooc.h
@@ -26,11 +26,16 @@
  * SOFTWARE.
  */
 
+
 #ifndef __PIKA_OOC_H__
 #define __PIKA_OOC_H__
-    #if PIKA_PLOOC_ENABLE
-        #include "../pikascript-lib/PLOOC/plooc_class.h"
-    #else
+    /* non-reentrant part */
+    #if !defined(PIKA_PLOOC_ENABLE) || !PIKA_PLOOC_ENABLE
         #define private_member(...) __VA_ARGS__
     #endif
+#endif
+
+/* plooc_class.h should support reentrant */
+#if PIKA_PLOOC_ENABLE
+    #include "../pikascript-lib/PLOOC/plooc_class.h"
 #endif

--- a/src/dataMemory.h
+++ b/src/dataMemory.h
@@ -31,7 +31,7 @@
 #include "PikaPlatform.h"
 #include "PikaVersion.h"
 
-/*! \NOTE: Make sure #include "plooc_class.h" is close to the class definition
+/*! \NOTE: Make sure #include "__pika_ooc.h" is close to the class definition
  */
 #if defined(__DATA_MEMORY_CLASS_IMPLEMENT__)
 #define __PLOOC_CLASS_IMPLEMENT__

--- a/src/dataQueue.c
+++ b/src/dataQueue.c
@@ -24,7 +24,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+#define  __DATA_QUEUE_CLASS_IMPLEMENT__
 #include "dataQueue.h"
 #include "PikaPlatform.h"
 #include "dataArgs.h"
@@ -93,4 +93,130 @@ int32_t queue_pushStr(Queue* queue, char* str) {
 
 char* queue_popStr(Queue* queue) {
     return arg_getStr(__queue_popArg_noRmoveArg(queue));
+}
+
+
+ByteQueue *byte_queue_init( ByteQueue *queue, 
+                            void *buffer, 
+                            uint_fast16_t size, 
+                            PIKA_BOOL is_queue_full)
+{
+    pika_assert(NULL != queue);
+    pika_assert(NULL != buffer);
+    pika_assert(size > 0);
+
+    pika_platform_memset(queue, 0, sizeof(ByteQueue));
+
+    queue->buffer = buffer;
+    queue->buffer_size = size;
+
+    return queue;
+}
+
+PIKA_BOOL byte_queue_read_one(ByteQueue *queue, uint8_t *byte_ptr)
+{
+    pika_assert(NULL != queue);
+    uint8_t byte;
+    PIKA_BOOL result = PIKA_FALSE;
+
+    /* ------------------atomicity sensitive start---------------- */
+    do {
+        if ((queue->head == queue->tail) && (0 == queue->count)) {
+            /* empty */
+            break;
+        }
+
+        byte = queue->buffer[queue->head++];
+        queue->count--;
+        if (queue->head >= queue->buffer_size) {
+            queue->head = 0;
+        }
+
+        /* reset peek */
+        queue->peek_count = queue->count;
+        queue->peek = queue->head;
+
+        if (NULL != byte_ptr) {
+            *byte_ptr = byte;
+        }
+        result = PIKA_TRUE;
+    } while(0);
+    /* ------------------atomicity sensitive end  ---------------- */
+
+    return result;
+}
+
+PIKA_BOOL byte_queue_peek_one(ByteQueue *queue, uint8_t *byte_ptr)
+{
+    pika_assert(NULL != queue);
+    uint8_t byte;
+    PIKA_BOOL result = PIKA_FALSE;
+
+    /* ------------------atomicity sensitive start---------------- */
+    do {
+        if ((queue->peek == queue->tail) && (0 == queue->peek_count)) {
+            /* empty */
+            break;
+        }
+
+        byte = queue->buffer[queue->peek++];
+        queue->peek_count--;
+        if (queue->peek >= queue->buffer_size) {
+            queue->peek = 0;
+        }
+
+        if (NULL != byte_ptr) {
+            *byte_ptr = byte;
+        }
+        result = PIKA_TRUE;
+    } while(0);
+    /* ------------------atomicity sensitive end  ---------------- */
+
+    return result;
+}
+
+void byte_queue_reset_peek(ByteQueue *queue)
+{
+    pika_assert(NULL != queue);
+    /* ------------------atomicity sensitive start---------------- */
+    queue->peek_count = queue->count;
+    queue->peek = queue->head;
+    /* ------------------atomicity sensitive end  ---------------- */
+}
+
+
+void byte_queue_drop_all_peeked(ByteQueue *queue)
+{
+    pika_assert(NULL != queue);
+    /* ------------------atomicity sensitive start---------------- */
+    queue->count = queue->peek_count;
+    queue->head = queue->peek;
+    /* ------------------atomicity sensitive end  ---------------- */
+}
+
+
+PIKA_BOOL byte_queue_write_one(ByteQueue *queue, uint8_t byte)
+{
+    pika_assert(NULL != queue);
+    PIKA_BOOL result = PIKA_FALSE;
+
+    /* ------------------atomicity sensitive start---------------- */
+    do {
+        if ((queue->head == queue->tail) && (0 != queue->count)) {
+            /* full */
+            break;
+        }
+
+        queue->buffer[queue->tail++] = byte;
+        queue->count++;
+        queue->peek_count++;
+        if (queue->tail >= queue->buffer_size) {
+            queue->tail = 0;
+        }
+
+        result = PIKA_TRUE;
+    } while(0);
+    /* ------------------atomicity sensitive end  ---------------- */
+
+    return result;
 }

--- a/src/dataQueue.c
+++ b/src/dataQueue.c
@@ -5,6 +5,7 @@
  * MIT License
  *
  * Copyright (c) 2021 lyon 李昂 liang6516@outlook.com
+ * Copyright (c) 2023 Gorgon Meducer embedded_zhuroan@hotmail.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -109,6 +110,10 @@ ByteQueue *byte_queue_init( ByteQueue *queue,
 
     queue->buffer = buffer;
     queue->buffer_size = size;
+    if (is_queue_full) {
+        queue->count = size;
+        queue->peek_count = size;
+    }
 
     return queue;
 }
@@ -182,6 +187,16 @@ void byte_queue_reset_peek(ByteQueue *queue)
     queue->peek_count = queue->count;
     queue->peek = queue->head;
     /* ------------------atomicity sensitive end  ---------------- */
+}
+
+uint_fast16_t byte_queue_get_peeked_number(ByteQueue *queue)
+{
+    return queue->count - queue->peek_count;
+}
+
+uint_fast16_t byte_queue_peek_available_count(ByteQueue *queue)
+{
+    return queue->peek_count;
 }
 
 

--- a/src/dataQueue.h
+++ b/src/dataQueue.h
@@ -5,6 +5,7 @@
  * MIT License
  *
  * Copyright (c) 2021 lyon 李昂 liang6516@outlook.com
+ * Copyright (c) 2023 Gorgon Meducer embedded_zhuroan@hotmail.comByte
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,6 +79,8 @@ PIKA_BOOL byte_queue_read_one(ByteQueue *queue, uint8_t *byte_ptr);
 PIKA_BOOL byte_queue_peek_one(ByteQueue *queue, uint8_t *byte_ptr);
 void byte_queue_reset_peek(ByteQueue *queue);
 void byte_queue_drop_all_peeked(ByteQueue *queue);
+uint_fast16_t byte_queue_get_peeked_number(ByteQueue *queue);
+uint_fast16_t byte_queue_peek_available_count(ByteQueue *queue);
 PIKA_BOOL byte_queue_write_one(ByteQueue *queue, uint8_t byte);
 
 #endif

--- a/src/dataQueue.h
+++ b/src/dataQueue.h
@@ -29,6 +29,29 @@
 #define __DATA_QUEUE__H
 #include "dataArgs.h"
 
+/*! \NOTE: Make sure #include "__pika_ooc.h" is close to the class definition
+ */
+#if defined(__DATA_QUEUE_CLASS_IMPLEMENT__)
+    #define __PLOOC_CLASS_IMPLEMENT__
+    #undef __DATA_QUEUE_CLASS_IMPLEMENT__
+#endif
+#include "__pika_ooc.h"
+
+typedef struct ByteQueue ByteQueue;
+struct ByteQueue {
+private_member(
+    uint8_t *buffer;
+    uint16_t buffer_size;
+
+    uint16_t head;
+    uint16_t tail;
+    uint16_t peek;
+
+    uint16_t count;
+    uint16_t peek_count;
+)
+};
+
 typedef Args Queue;
 Queue* New_queue(void);
 
@@ -46,4 +69,15 @@ Arg* queue_popArg(Queue* queue);
 Arg* queue_popArg_notDeinitArg(Queue* queue);
 int32_t queue_deinit_stack(Queue* queue);
 void queue_init(Queue* queue);
+
+ByteQueue *byte_queue_init( ByteQueue *queue, 
+                            void *buffer, 
+                            uint_fast16_t size, 
+                            PIKA_BOOL is_queue_full);
+PIKA_BOOL byte_queue_read_one(ByteQueue *queue, uint8_t *byte_ptr);
+PIKA_BOOL byte_queue_peek_one(ByteQueue *queue, uint8_t *byte_ptr);
+void byte_queue_reset_peek(ByteQueue *queue);
+void byte_queue_drop_all_peeked(ByteQueue *queue);
+PIKA_BOOL byte_queue_write_one(ByteQueue *queue, uint8_t byte);
+
 #endif

--- a/src/pika_config_valid.h
+++ b/src/pika_config_valid.h
@@ -352,6 +352,10 @@
         #define PIKA_SHELL_FILTER_ENABLE 0
     #endif
 
+    #ifndef PIKA_SHELL_FILTER_FIFO_SIZE
+        #define PIKA_SHELL_FILTER_FIFO_SIZE    32
+    #endif
+
     #ifndef PIKA_EVENT_LIST_SIZE
         #define PIKA_EVENT_LIST_SIZE 16
     #endif


### PR DESCRIPTION
- set macro `PIKA_SHELL_FILTER_ENABLE` to `1` to enable the feature
- define macro `PIKA_SHELL_FILTER_FIFO_SIZE` to set the filter buffer size.
- add your default filters (string, array) to `__default_filter_msg_table.cfg` at compile-time
- register your filters to `ShellConfig` instance at runtime. 
