### PR TITLE
Fix a bug of _OP_POW

### DIFF
--- a/src/PikaVM.c
+++ b/src/PikaVM.c
@@ -2734,11 +2734,20 @@ static void _OPT_POW(OperatorInfo* op) {
         return;
     }
     if (op->t1 == ARG_TYPE_INT && op->t2 == ARG_TYPE_INT) {
-        int res = 1;
-        for (int i = 0; i < op->i2; i++) {
-            res = res * op->i1;
+        int lhs = op->i1;
+        int rhs = op->i2;
+        if(rhs < 0) rhs = -rhs;
+        int64_t ret = 1;
+        while(rhs){
+            if(rhs & 1) ret *= lhs;
+            lhs *= lhs;
+            rhs >>= 1;
         }
-        op->res = arg_setInt(op->res, "", res);
+        if(op->i2 < 0){
+            op->res = arg_setFloat(op->res, "", 1.0/ret);
+        }else{
+            op->res = arg_setInt(op->res, "", ret);
+        }
         return;
     } else if (op->t1 == ARG_TYPE_FLOAT && op->t2 == ARG_TYPE_INT) {
         float res = 1;


### PR DESCRIPTION
Previously, `int` pow only considers positive operands. However, `2 ** -1` could be `0.5` which is a float number.

This pr uses quick pow algorithm which is of `O(log2N)` complexity instead of `O(N)` and handles negative operand.
Now these examples work as expected.

```
>>> 2 ** -1
0.500000
>>> 3** -2
0.111111
>>> 1 ** 0
1
>>> 2 ** 8
256
```