### PR TITLE
Fix non-constant format string

### DIFF
--- a/src/PikaObj.c
+++ b/src/PikaObj.c
@@ -1739,7 +1739,7 @@ enum shellCTRL _inner_do_obj_runChar(PikaObj* self,
         shell->lineBuff[shell->line_position] = 0;
         if (shell->line_curpos != shell->line_position) {
             /* update screen */
-            pika_platform_printf(shell->lineBuff + shell->line_curpos);
+            pika_platform_printf("%s", shell->lineBuff + shell->line_curpos);
             pika_platform_printf(" ");
             _putc_cmd(PIKA_KEY_LEFT,
                       shell->line_position - shell->line_curpos + 1);
@@ -1762,7 +1762,7 @@ enum shellCTRL _inner_do_obj_runChar(PikaObj* self,
                                   shell->line_position - shell->line_curpos);
             shell->lineBuff[shell->line_position + 1] = 0;
             if (shell->line_curpos != shell->line_position) {
-                pika_platform_printf(shell->lineBuff + shell->line_curpos + 1);
+                pika_platform_printf("%s", shell->lineBuff + shell->line_curpos + 1);
                 _putc_cmd(PIKA_KEY_LEFT,
                           shell->line_position - shell->line_curpos);
             }


### PR DESCRIPTION
Passing a non-constant 'format' string to a printf-like function can lead to a mismatch between the number of arguments defined by the 'format' and the number of arguments actually passed to the function. If the format string ultimately stems from an untrusted source, this can be used for exploits.