### PR TITLE
Fix incorrect check for error of tcsetattr()

### DIFF
--- a/src/PikaObj.c
+++ b/src/PikaObj.c
@@ -715,7 +715,7 @@ static int set_disp_mode(int fd, int option) {
     else
         term.c_lflag &= ~ECHOFLAGS;
     err = tcsetattr(fd, TCSAFLUSH, &term);
-    if (err == -1 && err == EINTR) {
+    if (err == -1) {
         perror("Cannot set the attribution of the terminal");
         return 1;
     }


### PR DESCRIPTION
Prior to this commit, the code was incorrectly checking whether tcsetattr() succeeded or not: The condition (err == -1 && err == EINTR) is always false.